### PR TITLE
Fs2 0.10.0 m3 (#31)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val lolhttp =
   settings(commonSettings: _*).
   settings(
     libraryDependencies ++= Seq(
-      "co.fs2" %% "fs2-core" % "0.9.5",
+      "co.fs2" %% "fs2-core" % "0.10.0-M3",
       "io.netty" % "netty-codec-http2" % "4.1.11.Final",
       "org.scalatest" %% "scalatest" % "3.0.1" % "test"
     ),

--- a/core/src/main/scala/Request.scala
+++ b/core/src/main/scala/Request.scala
@@ -2,7 +2,9 @@ package lol.http
 
 import scala.concurrent.{ Future }
 
-import fs2.{ Task, Stream }
+import cats.effect.IO
+
+import fs2.{ Stream }
 
 /** An HTTP request.
   *
@@ -46,13 +48,13 @@ case class Request(
     * @param decoder the [[ContentDecoder]] to use to read the content.
     * @return eventually a value of type `A`.
     */
-  def readAs[A](implicit decoder: ContentDecoder[A]): Future[A] = content.as[A].unsafeRunAsyncFuture
+  def readAs[A](implicit decoder: ContentDecoder[A]): Future[A] = content.as[A].unsafeToFuture
 
   /** Consume the content attached to this request by evaluating the provided effect function.
     * @param effect the function to use to consume the stream.
     * @return eventually a value of type `A`.
     */
-  def read[A](effect: Stream[Task,Byte] => Task[A]): Future[A] = effect(content.stream).unsafeRunAsyncFuture
+  def read[A](effect: Stream[IO,Byte] => IO[A]): Future[A] = effect(content.stream).unsafeToFuture
 
   /** Drain the content attached to this request. It is safe to call this operation even if the stream has
     * already been consumed.

--- a/core/src/main/scala/ServerSentEvents.scala
+++ b/core/src/main/scala/ServerSentEvents.scala
@@ -1,6 +1,7 @@
 package lol.http
 
-import fs2.{Stream, Chunk, Task}
+import cats.effect.IO
+import fs2.{ Stream, Chunk }
 import fs2.text
 
 /** Support for Server Sent Events content. It allows a server to stream
@@ -23,13 +24,13 @@ object ServerSentEvents {
 
   /** Decode the string event payload as a value of type A. */
   trait EventDecoder[+A] {
-    def apply(data: String): Task[A]
+    def apply(data: String): IO[A]
   }
 
   /** Provides default EventDecoders. */
   object EventDecoder {
     implicit val stringDecoder = new EventDecoder[String] {
-      def apply(value: String) = Task.now(value)
+      def apply(value: String) = IO.pure(value)
     }
   }
 
@@ -46,24 +47,25 @@ object ServerSentEvents {
   private val EVENT = chunk("event: ")
   private val ID = chunk("id: ")
 
-  private[http] def encoder[A](eventEncoder: EventEncoder[A]): ContentEncoder[Stream[Task, Event[A]]] = new ContentEncoder[Stream[Task, Event[A]]] {
-    def apply(events: Stream[Task, Event[A]]) =
-      Content(events.map { case Event(data, maybeEvent, maybeId) =>
-        Chunk.concat(
+  private[http] def encoder[A](eventEncoder: EventEncoder[A]): ContentEncoder[Stream[IO, Event[A]]] = new ContentEncoder[Stream[IO, Event[A]]] {
+    def apply(events: Stream[IO, Event[A]]) = {
+      val e = events.map {
+        case Event(data, maybeEvent, maybeId) =>
           maybeEvent.map(str => Seq(EVENT, chunk(str), `\n`)).getOrElse(Nil) ++
           maybeId.map(str => Seq(ID, chunk(str), `\n`)).getOrElse(Nil) ++
           eventEncoder(data).split("\n").flatMap(str => Seq(DATA, chunk(str), `\n`)) ++
           Seq(`\n`)
-        )
-      }.flatMap(Stream.chunk), Map(h"Content-Type" -> h"text/event-stream"))
+      }.flatMap(s => Stream.emits(s)).flatMap(s => Stream.chunk(s))
+      Content(e, Map(h"Content-Type" -> h"text/event-stream"))
+    }
   }
 
-  private[http] def decoder[A](eventDecoder: EventDecoder[A]): ContentDecoder[Stream[Task, Event[A]]] = new ContentDecoder[Stream[Task, Event[A]]] {
+  private[http] def decoder[A](eventDecoder: EventDecoder[A]): ContentDecoder[Stream[IO, Event[A]]] = new ContentDecoder[Stream[IO, Event[A]]] {
     def apply(content: Content) =
       if(content.headers.get(h"Content-Type").exists(_ == h"text/event-stream"))
-        Task.now {
+        IO.pure {
           content.stream.through(text.utf8Decode).through(text.lines).
-            scan(Left((new StringBuilder, None, None)):Either[(StringBuilder,Option[String],Option[String]), Task[Event[A]]]) {
+            scan(Left((new StringBuilder, None, None)):Either[(StringBuilder,Option[String],Option[String]), IO[Event[A]]]) {
               case (seed, line) =>
                 val (dataBuffer, maybeEvent, maybeId) = seed match {
                   case Left(x) => x
@@ -93,7 +95,7 @@ object ServerSentEvents {
             evalMap(identity)
         }
       else
-        Task.fail {
+        IO.raiseError {
           Error.UnexpectedContentType(s"Expected `text/event-stream' content but got `${content.headers.get(h"Content-Type").getOrElse("")}'")
         }
   }

--- a/core/src/main/scala/internal/NettySupport.scala
+++ b/core/src/main/scala/internal/NettySupport.scala
@@ -1,40 +1,41 @@
 package lol.http.internal
 
-import fs2.{ Stream, Strategy, Chunk, Task, Pull, Sink, async }
+import scala.concurrent.ExecutionContext
+
+import cats.effect.{ IO }
+import fs2.{ Chunk, Pull, Segment, Sink, Stream, async }
 
 import io.netty.channel.{
   Channel,
   ChannelFuture,
-  SimpleChannelInboundHandler,
-  ChannelHandlerContext }
+  ChannelHandlerContext,
+  SimpleChannelInboundHandler }
 import io.netty.handler.logging.{ LogLevel, LoggingHandler }
 import io.netty.util.concurrent.{ GenericFutureListener }
 import io.netty.buffer.{ Unpooled, ByteBuf }
 import io.netty.handler.codec.http.{
-  HttpObject,
-  HttpContent,
-  LastHttpContent,
-  HttpMessage,
-  HttpResponse,
   DefaultHttpContent,
-  DefaultHttpResponse,
   DefaultHttpRequest,
+  DefaultHttpResponse,
   DefaultLastHttpContent,
   HttpClientCodec,
-  HttpResponseEncoder,
-  HttpRequestDecoder,
+  HttpContent,
   HttpContentDecompressor,
-  HttpMethod => NettyHttpMethod,
-  HttpVersion => NettyHttpVersion,
-  HttpResponseStatus,
+  HttpMessage,
+  HttpObject,
   HttpRequest,
-  HttpUtil }
+  HttpRequestDecoder,
+  HttpResponse,
+  HttpResponseEncoder,
+  HttpResponseStatus,
+  HttpUtil,
+  LastHttpContent,
+  HttpMethod => NettyHttpMethod,
+  HttpVersion => NettyHttpVersion }
 
 import scala.concurrent.{ Future, Promise }
 import scala.collection.mutable.{ ListBuffer }
 import collection.JavaConverters._
-
-import fs2.{ Task }
 
 import lol.http._
 
@@ -55,8 +56,8 @@ private[http] object NettySupport {
       })
       p.future
     }
-    def toTask(implicit S: Strategy): Task[Channel] = {
-      Task.async { cb =>
+    def toIO: IO[Channel] = {
+      IO.async { cb =>
         try {
           f.addListener(new GenericFutureListener[ChannelFuture] {
             override def operationComplete(f: ChannelFuture) = {
@@ -78,15 +79,29 @@ private[http] object NettySupport {
   }
 
   implicit class NettyByteBuffer(buffer: ByteBuf) {
+    def toSegment: Segment[Byte, Unit] = {
+      val segments = ListBuffer.empty[Segment[Byte, Unit]]
+      while (buffer.readableBytes > 0) {
+        val bytes = Array.ofDim[Byte](buffer.readableBytes)
+        buffer.readBytes(bytes)
+        segments += Chunk.bytes(bytes)
+      }
+      segments.foldLeft(Segment.empty[Byte])((acc, seg) => acc ++ seg)
+    }
+
     def toChunk: Chunk[Byte] = {
       val chunks = ListBuffer.empty[Chunk[Byte]]
-      while(buffer.readableBytes > 0) {
+      while (buffer.readableBytes > 0) {
         val bytes = Array.ofDim[Byte](buffer.readableBytes)
         buffer.readBytes(bytes)
         chunks += Chunk.bytes(bytes)
       }
-      Chunk.concat(chunks)
+      Segment.seq(chunks).flattenChunks.toChunk
     }
+  }
+
+  implicit class SegmentByteBuffer(segment: Segment[Byte, Unit]) {
+    def toByteBuf: ByteBuf = Unpooled.wrappedBuffer(segment.toChunk.toArray)
   }
 
   implicit class ChunkByteBuffer(chunk: Chunk[Byte]) {
@@ -107,49 +122,48 @@ private[http] object NettySupport {
       latch.await
       result.get
     }
-
-    def httpContentSink(implicit S: Strategy): Sink[Task,Byte] = {
-      _.repeatPull(_.awaitOption.flatMap {
-        case Some((chunk, h)) =>
-          Pull.eval(
-            if(channel.isOpen)
-              channel.writeAndFlush(new DefaultHttpContent(chunk.toByteBuf)).toTask
-            else
-              Task.fail(Error.ConnectionClosed)
-          ) as h
-        case None =>
-          Pull.eval(
-            if(channel.isOpen)
-              channel.writeAndFlush(new DefaultLastHttpContent()).toTask
-            else
-              Task.fail(Error.ConnectionClosed)
-          ) >> Pull.done
-      })
+    // Pull[IO, Nothing, Stream[IO, Byte]]
+    def httpContentSink: Sink[IO, Byte] = {
+      _.repeatPull { s =>
+        s.unconsChunk.flatMap {
+          case Some((chunk, t)) =>
+            Pull.eval {
+              if (channel.isOpen) channel.writeAndFlush(new DefaultHttpContent(Unpooled.wrappedBuffer(chunk.toArray))).toIO
+              else IO.raiseError(Error.ConnectionClosed)
+            }.as(Some(t))
+          case None =>
+            Pull.eval {
+              if (channel.isOpen) channel.writeAndFlush(new DefaultLastHttpContent()).toIO
+              else IO.raiseError(Error.ConnectionClosed)
+            } >> Pull.pure(None)
+        }
+      }
     }
 
-    def bytesSink(implicit S: Strategy): Sink[Task,Byte] = {
-      _.repeatPull(_.awaitOption.flatMap {
-        case Some((chunk, h)) =>
-          Pull.eval(
-            if(channel.isOpen)
-              channel.writeAndFlush(chunk.toByteBuf).toTask
-            else
-              Task.fail(Error.ConnectionClosed)
-          ) as h
-        case None =>
-          Pull.done
-      })
+    def bytesSink: Sink[IO, Byte] = {
+      _.repeatPull { s =>
+        s.unconsChunk.flatMap {
+          case Some((chunk, t)) =>
+            Pull.eval {
+              if (channel.isOpen) channel.writeAndFlush(Unpooled.wrappedBuffer(chunk.toArray)).toIO
+              else IO.raiseError(Error.ConnectionClosed)
+            }.as(Some(t))
+          case None =>
+            Pull.pure(None)
+        }
+      }
     }
+
   }
 
   object Netty {
-    def clientConnection(channel: Channel, debug: Option[String])(implicit S: Strategy): ClientConnection = {
+    def clientConnection(channel: Channel, debug: Option[String])(implicit ec: ExecutionContext): ClientConnection = {
       debug.foreach(logger => channel.pipeline.addLast("Debug", new LoggingHandler(logger, LogLevel.INFO)))
       channel.pipeline.addLast("HttpClientCodec", new HttpClientCodec())
       channel.pipeline.addLast("HttpDecompress", new HttpContentDecompressor())
       val http1xConnection = new Http1xConnection(channel, client = true)
       new ClientConnection {
-        def apply(request: Request, release: () => Unit): Task[Response] =
+        def apply(request: Request, release: () => Unit): IO[Response] =
           for {
             nettyRequest <- {
               val nettyRequest = new DefaultHttpRequest(
@@ -164,11 +178,11 @@ private[http] object NettySupport {
                 nettyRequest
               }
             }
-            response <- http1xConnection.read().flatMap {
+            response <- http1xConnection.read.flatMap {
               case (nettyResponse: HttpResponse, contentStream) =>
                 for {
-                  readers <- async.semaphore[Task](1)
-                  upgradedReaders <- async.semaphore[Task](1)
+                  readers <- async.semaphore[IO](1)
+                  upgradedReaders <- async.semaphore[IO](1)
                 } yield {
                   val response: Response = Response(
                     status = nettyResponse.status.code,
@@ -186,7 +200,7 @@ private[http] object NettySupport {
                               case true =>
                                 contentStream.onFinalize(
                                   if(HttpUtil.isKeepAlive(nettyRequest) && HttpUtil.isKeepAlive(nettyResponse)) {
-                                    Task.delay(release())
+                                    IO(release())
                                   }
                                   else {
                                     http1xConnection.close
@@ -236,21 +250,21 @@ private[http] object NettySupport {
       }
     }
 
-    def serverConnection(channel: Channel, debug: Option[String])(implicit S: Strategy): ServerConnection = {
+    def serverConnection(channel: Channel, debug: Option[String])(implicit ec: ExecutionContext): ServerConnection = {
       debug.foreach(logger => channel.pipeline.addLast("Debug", new LoggingHandler(logger, LogLevel.INFO)))
       channel.pipeline.addLast("HttpRequestDecoder", new HttpRequestDecoder())
       channel.pipeline.addLast("HttpResponseEncoder", new HttpResponseEncoder())
       val http1xConnection = new Http1xConnection(channel, client = false)
       new ServerConnection {
-        val lock = async.semaphore[Task](1).unsafeRun()
-        def apply(): Task[(Request, Response => Task[Unit])] =
+        val lock = async.semaphore[IO](1).unsafeRunSync()
+        def apply(): IO[(Request, Response => IO[Unit])] =
           for {
-            _ <- lock.decrement.race(http1xConnection.closed)
-            request <- http1xConnection.read().flatMap {
+            _ <- async.race(lock.decrement, http1xConnection.closed)
+            request <- http1xConnection.read.flatMap {
               case (nettyRequest: HttpRequest, contentStream) =>
                 for {
                   // Track the number of content readers
-                  readers <- async.semaphore[Task](1)
+                  readers <- async.semaphore[IO](1)
                 } yield {
                   Request(
                     method = HttpMethod(nettyRequest.method.name),
@@ -278,7 +292,7 @@ private[http] object NettySupport {
                 Panic.!!!(s"Expected HttpRequest, got ${x}")
             }
           } yield {
-            request -> (response => {
+            request -> ((response: Response) => {
               val nettyResponse = new DefaultHttpResponse(
                 NettyHttpVersion.HTTP_1_1,
                 HttpResponseStatus.valueOf(response.status)
@@ -297,7 +311,7 @@ private[http] object NettySupport {
                     }
                   }
                   else {
-                    Task.now(())
+                    IO.pure(())
                   }
                 }
                 _ <- lock.increment
@@ -315,35 +329,35 @@ private[http] object NettySupport {
   trait ClientConnection {
     // Send a request and a callback allowing the underlying impl to
     // release the connection, and eventually receive the response.
-    def apply(request: Request, release: () => Unit): Task[Response]
+    def apply(request: Request, release: () => Unit): IO[Response]
     def isOpen: Boolean
-    def close: Task[Unit]
-    def closed: Task[Unit]
+    def close: IO[Unit]
+    def closed: IO[Unit]
   }
   trait ServerConnection {
     // Wait for a request and a callback allowing to send the correponding
     // response when it is ready.
-    def apply(): Task[(Request, Response => Task[Unit])]
+    def apply(): IO[(Request, Response => IO[Unit])]
     def isOpen: Boolean
-    def close: Task[Unit]
-    def closed: Task[Unit]
+    def close: IO[Unit]
+    def closed: IO[Unit]
   }
 
-  class Http1xConnection(channel: Channel, client: Boolean)(implicit S: Strategy) {
+  class Http1xConnection(channel: Channel, client: Boolean)(implicit ec: ExecutionContext) {
     // At first we set the channel in auto read to get the first message
     channel.config.setAutoRead(true)
 
     val (messages, content, permits) = (for {
       // The HTTP messages buffer. We use an unboundedQueue here but
       // because we only 1 message at a time, the effective size will be 1.
-      messages <- async.unboundedQueue[Task,Option[(HttpMessage,Boolean)]]
+      messages <- async.unboundedQueue[IO,Option[(HttpMessage,Boolean)]]
       // The content buffer. We use also an unboundedQueue here but
       // because we ask netty to stop to read as soon as we have one chunk,
       // so the effective size will be 1 as well.
-      content <- async.unboundedQueue[Task,Option[Chunk[Byte]]]
+      content <- async.unboundedQueue[IO,Option[Chunk[Byte]]]
       // Track usages. We only allow one message to be write/read at a time.
-      permits <- async.semaphore[Task](1)
-    } yield (messages, content, permits)).unsafeRun()
+      permits <- async.semaphore[IO](1)
+    } yield (messages, content, permits)).unsafeRunSync()
 
     // Each time we consume a chunk we ask the channel
     // to read the next message. When this chunk has been
@@ -351,7 +365,7 @@ private[http] object NettySupport {
     // Because we are now consuming this chunk, we can inform the
     // socket that we are ready to receive new data.
     val contentStream =
-      content.dequeue.evalMap { chunk => Task.delay(if(chunk.isDefined) channel.read()).map(_ => chunk) }
+      content.dequeue.evalMap { chunk => IO(if(chunk.isDefined) channel.read()).map(_ => chunk) }
 
     channel.pipeline.addLast("HttpStreamHandler", new SimpleChannelInboundHandler[HttpObject]() {
       // Mutable reference is safe here because the code is single threaded.
@@ -375,20 +389,20 @@ private[http] object NettySupport {
           (if(hasContent(message)) {
             (for {
               _ <- messages.enqueue1(Some(message -> true))
-              _ <- Task.delay(skipContent = false)
-              _ <- Task.delay(channel.config.setAutoRead(false))
+              _ <- IO(skipContent = false)
+              _ <- IO(channel.config.setAutoRead(false))
             } yield ())
           }
           else {
             (for {
               _ <- messages.enqueue1(Some(message -> false))
-              _ <- Task.delay(skipContent = true)
+              _ <- IO(skipContent = true)
             } yield ())
-          }).unsafeRun()
+          }).unsafeRunSync()
         // We ignore the content and the last chunk has been received,
         // mark the connection ready for next message.
         case lastChunk: LastHttpContent if skipContent =>
-          (if(client) permits.increment else permits.decrement).unsafeRun()
+          (if(client) permits.increment else permits.decrement).unsafeRunSync()
         // Should not happen, unless the client send us a GET/HEAD request
         // with a content body and we will ignore it anyawy
         case chunk: HttpContent if skipContent =>
@@ -402,14 +416,14 @@ private[http] object NettySupport {
             _ <- content.enqueue1(Some(buffer))
             _ <- content.enqueue1(Some(lastChunk.content.toChunk))
             _ <- content.enqueue1(None)
-            _ <- Task.delay {
+            _ <- IO {
               buffer = Chunk.empty
               channel.config.setAutoRead(true)
             }
-          } yield ()).unsafeRun()
+          } yield ()).unsafeRunSync()
         // A content chunk has been received. Add it to the buffer.
         case chunk: HttpContent =>
-          buffer = Chunk.concat(Seq(buffer, chunk.content.toChunk))
+          buffer = chunk.content.toChunk.prepend(buffer).toChunk
       }
 
       // No more data available on the socket. Enqueue the buffered
@@ -417,8 +431,8 @@ private[http] object NettySupport {
       override def channelReadComplete(ctx: ChannelHandlerContext) = {
         (for {
           _ <- content.enqueue1(Some(buffer))
-          _ <- Task.delay(buffer = Chunk.empty)
-        } yield ()).unsafeRun()
+          _ <- IO(buffer = Chunk.empty)
+        } yield ()).unsafeRunSync()
       }
     })
 
@@ -426,7 +440,7 @@ private[http] object NettySupport {
       override def channelRead0(ctx: ChannelHandlerContext, msg: Any) = msg match {
         // If we have switched protocol, we now receive raw bytes buffer here.
         case msg: ByteBuf =>
-          content.enqueue1(Some(msg.toChunk)).unsafeRun()
+          content.enqueue1(Some(msg.toChunk)).unsafeRunSync()
           // Stop reading automatically now, user code will pull the stream.
           channel.config.setAutoRead(false)
         case _ =>
@@ -444,72 +458,73 @@ private[http] object NettySupport {
     // When the channel is closed we push None to the message
     // queue, to indicate the End Of Stream. We also push None
     // to the content queue to force incomplete stream to finish.
-    lazy val closed: Task[Unit] = channel.closeFuture.toTask.flatMap { _ =>
-      (for {
+    lazy val closed: IO[Unit] = channel.closeFuture.toIO.flatMap { _ =>
+      for {
         _ <- messages.enqueue1(None)
         _ <- content.enqueue1(None)
-      } yield ())
+      } yield ()
     }
 
     def isOpen: Boolean = channel.isOpen
-    def close: Task[Unit] = Task.delay(if(channel.isOpen) channel.close())
+    def close: IO[Unit] = IO(if(channel.isOpen) channel.close())
 
     // Read one HTTP message along with its content stream. The
     // content stream must be read before the next message to be
     // available.
-    def read(): Task[(HttpMessage,Stream[Task,Byte])] =
+    def read: IO[(HttpMessage, Stream[IO, Byte])] =
       messages.dequeue1.flatMap {
         case Some((message, true)) =>
           for {
-            readers <- async.semaphore[Task](1) // Keep track of the number of readers
-            eosReached <- async.signalOf[Task,Boolean](false) // Keep track of the End Of Stream
+            readers <- async.semaphore[IO](1)
+            eosReached <- async.signalOf[IO, Boolean](false)
             messageStream =
               Stream.
                 // The content stream can be read only once
                 eval(readers.tryDecrement).flatMap {
-                  case false =>
-                    Stream.fail(Error.StreamAlreadyConsumed)
-                  case true =>
-                    contentStream.
-                      // We read the queue until a None, that mark
-                      // the content stream end.
-                      evalMap { chunk => eosReached.set(chunk.isEmpty).map(_ => chunk) }.
-                      takeWhile(_.isDefined).
-                      // The stream of bytes
-                      flatMap(chunk => Stream.chunk(chunk.get)).
-                      // When user code finished to consume this stream, we need
-                      // to drain the remaining content if the eos has not been
-                      // reached yet.
-                      onFinalize(for {
+                case false =>
+                  Stream.fail(Error.StreamAlreadyConsumed)
+                case true =>
+                  contentStream.
+                    // We read the queue until a None, that marks
+                    // the content stream end.
+                    evalMap(chunk => eosReached.set(chunk.isEmpty).map(_ => chunk)).
+                    takeWhile(_.isDefined).
+                    // The stream of bytes
+                    flatMap(chunk => Stream.chunk(chunk.get)).
+                    // When user code finishes consuming this stream, we need
+                    // to drain the remaining content if the eos has not been
+                    // reached yet.
+                    onFinalize {
+                      for {
                         fullyRead <- eosReached.get
-                        _ <- if(fullyRead) Task.now(()) else contentStream.takeWhile(_.isDefined).drain.run
-                        _ <- if(client) permits.increment else permits.decrement
-                      } yield ())
-                }
+                        _ <- if (fullyRead) IO.pure(()) else contentStream.takeWhile(_.isDefined).drain.run
+                        _ <- if (client) permits.increment else permits.decrement
+                      } yield ()
+                    }
+              }
           } yield (message, messageStream)
-        case Some((message, false)) =>
-          Task.now((message, Stream.empty))
-        case _ =>
-          Task.fail(Error.ConnectionClosed)
+        case Some((message, false)) => IO.pure((message, Stream.empty))
+        case _ => IO.raiseError(Error.ConnectionClosed)
       }
 
+
     // Write an HTTP message along with its content to the channel.
-    def write(message: HttpMessage, contentStream: Stream[Task,Byte]): Task[Unit] =
+    def write(message: HttpMessage, contentStream: Stream[IO,Byte]): IO[Unit] =
       for {
         _ <- if(client) permits.decrement else permits.increment
-        _ <- if(channel.isOpen) Task.delay(channel.writeAndFlush(message)) else Task.fail(Error.ConnectionClosed)
+        _ <- if(channel.isOpen) IO(channel.writeAndFlush(message)) else IO.raiseError(Error.ConnectionClosed)
         _ <- (contentStream to channel.httpContentSink).run
-        _ <- Task.delay(if(message.isInstanceOf[HttpResponse] && HttpUtil.getContentLength(message, -1) < 0) channel.close())
+        _ <- IO(if(message.isInstanceOf[HttpResponse] && HttpUtil.getContentLength(message, -1) < 0) channel.close())
       } yield ()
 
     // Upgrade the connection to a plain TCP connection: we deregister
     // all the netty HTTP pipeline.
-    def upgrade(): Task[Stream[Task,Byte]] =
+    def upgrade(): IO[Stream[IO,Byte]] =
       for {
         _ <- permits.decrement
         _ <- messages.enqueue1(None)
-        in <- Task.delay {
-          channel.runInEventLoop[Stream[Task,Byte]] {
+        in <- IO {
+          channel.runInEventLoop[Stream[IO,Byte]] {
             channel.pipeline.names.asScala.filter(_.startsWith("Http")).foreach(channel.pipeline.remove)
             // Read the next message
             channel.read()

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -1,6 +1,8 @@
 package lol
 
-import fs2.{ Stream, Task}
+import cats.effect.IO
+
+import fs2.{ Stream }
 
 import scala.concurrent.{ Future }
 
@@ -79,7 +81,7 @@ package object http {
     * @param upgradeConnection this function will be called with the upstream as parameter and must retun the downstream.
     * @return a 101 [[Response]].
     */
-  def SwitchingProtocol(protocol: HttpString, upgradeConnection: (Stream[Task,Byte]) => Stream[Task,Byte]) = {
+  def SwitchingProtocol(protocol: HttpString, upgradeConnection: (Stream[IO,Byte]) => Stream[IO,Byte]) = {
     Response(101, upgradeConnection = upgradeConnection).
       addHeaders(Headers.Upgrade -> protocol, Headers.Connection -> h"Upgrade")
   }

--- a/core/src/test/scala/ContentTests.scala
+++ b/core/src/test/scala/ContentTests.scala
@@ -30,13 +30,13 @@ class ContentTests extends Tests {
     val text = "Do you speak English? えいごをはなせますか"
     val textContent = Content.of(text)
 
-    textContent.as[String].unsafeRun() should be (text)
-    textContent.as(ContentDecoder.text(defaultCodec = Codec.ISO8859)).unsafeRun() should not be (text)
-    textContent.as(ContentDecoder.text(maxSize = 21)).unsafeRun() should be (text.take(21))
+    textContent.as[String].unsafeRunSync() should be (text)
+    textContent.as(ContentDecoder.text(defaultCodec = Codec.ISO8859)).unsafeRunSync() should not be (text)
+    textContent.as(ContentDecoder.text(maxSize = 21)).unsafeRunSync() should be (text.take(21))
 
     // A truncated byte buffer is not necessarely a valid utf-8 sequence
     a [java.nio.charset.MalformedInputException] should be thrownBy {
-      textContent.as(ContentDecoder.text(maxSize = 23)).unsafeRun()
+      textContent.as(ContentDecoder.text(maxSize = 23)).unsafeRunSync()
     }
   }
 
@@ -51,8 +51,8 @@ class ContentTests extends Tests {
       "H%C3%A9h%C3%A9=lol&H%C3%A9h%C3%A9=wat%26hop&Do+you+speak+English%3F=%E3%81%88%E3%81%84%E3%81%94" +
       "%E3%82%92%E3%81%AF%E3%81%AA%E3%81%9B%E3%81%BE%E3%81%99%E3%81%8B"
     )
-    formContent.as[Map[String,Seq[String]]].unsafeRun() should be (form)
-    formContent.as[Map[String,String]].unsafeRun() should be (Map(
+    formContent.as[Map[String,Seq[String]]].unsafeRunSync() should be (form)
+    formContent.as[Map[String,String]].unsafeRunSync() should be (Map(
       "Héhé" -> "lol",
       "Do you speak English?" -> "えいごをはなせますか"
     ))
@@ -67,7 +67,7 @@ class ContentTests extends Tests {
     new String(getBytes(formWithCharsetContent).toArray, "us-ascii") should be (
       "_charset_=windows-1252&H%E9h%E9=lol&H%E9h%E9=wat%26hop&Do+you+speak+English%3F=%26%2312360%3B%26%2312356%3B%26%2312372%3B%26%2312434%3B%26%2312399%3B%26%2312394%3B%26%2312379%3B%26%2312414%3B%26%2312377%3B%26%2312363%3B"
     )
-    formWithCharsetContent.as[Map[String,Seq[String]]].unsafeRun() should be (formWithCharset)
+    formWithCharsetContent.as[Map[String,Seq[String]]].unsafeRunSync() should be (formWithCharset)
   }
 
   test("InputStream", Pure) {
@@ -85,15 +85,14 @@ class ContentTests extends Tests {
 
     ContentEncoder.inputStream(chunkSize = 1, blockingExecutor = ec).apply(a).stream.chunks.map(c => new String(c.toArray)).
       interleave(Stream("_").repeat).
-      runLog.unsafeRun().mkString should be ("L_O_L_\n_")
+      runLog.unsafeRunSync().mkString should be ("L_O_L_\n_")
 
     ContentEncoder.inputStream(chunkSize = 2, blockingExecutor = ec).apply(a).stream.chunks.map(c => new String(c.toArray)).
       interleave(Stream("_").repeat).
-      runLog.unsafeRun().mkString should be ("LO_L\n_")
+      runLog.unsafeRunSync().mkString should be ("LO_L\n_")
   }
 
   test("File") {
-    import scala.concurrent.ExecutionContext.Implicits.global
 
     val url = this.getClass.getResource("/index.html")
     url != null should be (true)
@@ -122,7 +121,7 @@ class ContentTests extends Tests {
 
     val x = content2.stream.chunks.map(c => new String(c.toArray)).
       interleave(Stream("_").repeat).
-      runLog.unsafeRun().mkString
+      runLog.unsafeRunSync().mkString
 
     x should be (realContent.zip(0 to realContent.size map(_ => '_')).map { case (a,b) => "" + a + b }.mkString)
   }

--- a/core/src/test/scala/ServerTests.scala
+++ b/core/src/test/scala/ServerTests.scala
@@ -1,6 +1,7 @@
 package lol.http
 
-import fs2.{ Stream, Chunk, Task }
+import cats.effect.IO
+import fs2.{ Stream, Chunk }
 
 import scala.concurrent.{ ExecutionContext }
 import ExecutionContext.Implicits.global
@@ -121,10 +122,10 @@ class ServerTests extends Tests {
         }
     }) { server =>
       def oneMeg = Content(
-        Stream.eval(Task.delay(Chunk.bytes(("A" * 1024).getBytes("us-ascii")))).
+        Stream.eval(IO(Chunk.bytes(("A" * 1024).getBytes("us-ascii")))).
           repeat.
           take(1024).
-          flatMap(Stream.chunk),
+          flatMap(chunk => Stream.chunk(chunk)),
         Map(Headers.ContentLength -> HttpString(1024 * 1024))
       )
 

--- a/core/src/test/scala/Tests.scala
+++ b/core/src/test/scala/Tests.scala
@@ -16,17 +16,17 @@ abstract class Tests extends FunSuite with Matchers with OptionValues with Insid
   def await[A](atMost: Duration = 30 seconds)(a: Future[A]): A = Await.result(a, atMost)
   def withServer(server: Server)(test: Server => Unit) = try { test(server) } finally { server.stop() }
   def success[A](a: A) = Future.successful(a)
-  def status(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Int = {
+  def status(req: Request, atMost: Duration = 30 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Int = {
     await(atMost) { Client.run(req, followRedirects = followRedirects)(res => success(res.status)) }
   }
-  def contentString(req: Request, atMost: Duration = 5 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): String = {
+  def contentString(req: Request, atMost: Duration = 30 seconds, followRedirects: Boolean = true)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): String = {
     await(atMost) { Client.run(req, followRedirects = followRedirects)(_.readAs[String]) }
   }
-  def headers(req: Request, atMost: Duration = 5 seconds)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Map[HttpString,HttpString] = {
+  def headers(req: Request, atMost: Duration = 30 seconds)(implicit e: ExecutionContext, ssl: SSL.ClientConfiguration): Map[HttpString,HttpString] = {
     await(atMost) { Client.run(req)(res => Future.successful(res.headers)) }
   }
   def getString(content: Content, codec: String = "utf-8") = new String(getBytes(content).toArray, codec)
-  def getBytes(content: Content): Vector[Byte] = content.stream.runLog.unsafeRun()
+  def getBytes(content: Content): Vector[Byte] = content.stream.runLog.unsafeRunSync()
   def bytes(data: Int*): Seq[Byte] = data.map(_.toByte)
   val timer = new Timer(true)
   def timeout[A](d: Duration, a: A): Future[A] = {

--- a/json/src/main/scala/JsonContent.scala
+++ b/json/src/main/scala/JsonContent.scala
@@ -2,7 +2,7 @@ package lol.json
 
 import lol.http._
 
-import fs2.{ Task }
+import cats.effect.IO
 
 import scala.io.{ Codec }
 
@@ -32,7 +32,7 @@ object JsonContent {
   def decoder(maxSize: Int = ContentDecoder.MaxSize, codec: Codec = Codec.UTF8) = new ContentDecoder[Json] {
     def apply(content: Content) = {
       ContentDecoder.text()(content).flatMap { text =>
-        parse(text).fold(Task.fail, Task.now)
+        parse(text).fold(IO.raiseError, IO.pure)
       }
     }
   }
@@ -44,7 +44,7 @@ object JsonContent {
 
   /** A decoder for Server Sent Events. */
   def sseEventDecoder: ServerSentEvents.EventDecoder[Json] = new ServerSentEvents.EventDecoder[Json] {
-    def apply(data: String) = parse(data).fold(Task.fail, Task.now)
+    def apply(data: String) = parse(data).fold(IO.raiseError, IO.pure)
   }
 
 }

--- a/json/src/main/scala/package.scala
+++ b/json/src/main/scala/package.scala
@@ -2,7 +2,7 @@ package lol
 
 import http._
 
-import fs2.{ Task }
+import cats.effect.IO
 
 import io.circe.{ Decoder }
 
@@ -44,8 +44,8 @@ package object json {
     * @return a [[lol.http.ContentDecoder ContentDecoder]] for `A`.
     */
   def json[A](implicit jsonDecoder: Decoder[A]) = new ContentDecoder[A] {
-    def apply(content: Content) = defaultJsonDecoder(content).flatMap { json =>
-      json.as[A].fold(Task.fail, Task.now)
+    def apply(content: Content) = defaultJsonDecoder.apply(content).flatMap { json =>
+      json.as[A].fold(IO.raiseError, IO.pure)
     }
   }
 


### PR DESCRIPTION
* Refactoring to use fs2 0.10.0-M3 w/cats effect

* Refactoring to use fs2 0.10.0-M3 w/cats effect

* Refactoring to use fs2 0.10.0-M3 w/cats effect

* Changed atMost: Duration from 5 to 30 seconds.

* Removed unused fs2.Segment import, and unnecessary ExecutionContext implicits.

* Removed unused fs2.Segment import

* Removed unused cats import

* Reformat imports to be style-consistent, removed unused imports, restored omitted comments

* Removed unused ExecutionContext import due to removal of EC's in Content.scala